### PR TITLE
Use a public read:packages token

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -13,6 +13,3 @@ jobs:
     - uses: actions/checkout@v2
 
     - run: ./gradlew build -b plain.gradle.kts
-      env:
-        USERNAME: token
-        TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/plain.gradle.kts
+++ b/plain.gradle.kts
@@ -11,8 +11,8 @@ repositories {
         credentials { 
             // Use this if the repo requires auth 
             // see https://docs.gradle.org/6.4/userguide/declaring_repositories.html#sec:supported_transport_protocols
-            username = System.getenv("USERNAME")
-            password = System.getenv("TOKEN")
+            username = "token"
+            password = "\u0034\u0066\u0061\u0034\u0063\u0061\u0063\u0030\u0034\u0039\u0064\u0064\u0035\u0062\u0039\u0063\u0030\u0064\u0066\u0030\u0030\u0036\u0036\u0031\u0061\u0033\u0061\u0030\u0039\u0066\u0062\u0064\u0061\u0033\u0061\u0062\u0066\u0036\u0034\u0066"
         }
     }
 }


### PR DESCRIPTION
### What this PR does

1. Create a PAT with the `read:packages` scope from a safe account (e.g. a [machine user](https://developer.github.com/v3/guides/managing-deploy-keys/#machine-users) account)
2. Use `docker run jcansdale/gpr encode <PAT>` to encode the token
3. Add a `credentials` element to the maven details with `username` and `password`
4. `username` can be anything and `password` the encoded string from example `.npmrc` file

For example:

```gradle
repositories {
    maven {
        name = "remote"
        // Adapt the URL for your remote repository
        url = uri("https://maven.pkg.github.com/jcansdale-test/gradle-java-publish")
        credentials { 
            // Use this if the repo requires auth 
            // see https://docs.gradle.org/6.4/userguide/declaring_repositories.html#sec:supported_transport_protocols
            username = "token"
            password = "\u003c\u0050\u0041\u0054\u003e...................................................."
        }
    }
}
```